### PR TITLE
feat: Add FastAPI with health check endpoint

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,10 @@
+# To run this FastAPI application independently, use the following command in your terminal:
+# uvicorn backend.api:app --reload --port 8000
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,4 +6,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "websockets>=14.1",
+    "fastapi",
+    "uvicorn[standard]",
 ]
+
+[project.group.dev.dependencies]
+httpx = "*"

--- a/backend/test_api.py
+++ b/backend/test_api.py
@@ -1,0 +1,10 @@
+import pytest
+from httpx import AsyncClient
+from backend.api import app # Assuming app is directly importable
+
+@pytest.mark.asyncio
+async def test_health_check():
+    async with AsyncClient(app=app, base_url="http://127.0.0.1:8000") as client:
+        response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
- Added `fastapi` and `uvicorn[standard]` to backend dependencies.
- Created `backend/api.py` with a FastAPI application.
- Implemented a `/health` GET endpoint that returns `{"status": "ok"}`.
- Added instructions in `backend/api.py` on how to run the FastAPI server using `uvicorn backend.api:app --reload --port 8000`.
- Added `httpx` as a dev dependency for testing.
- Created `backend/test_api.py` with an asynchronous test for the `/health` endpoint, ensuring it returns a 200 status and the correct JSON response.